### PR TITLE
fileformat: update for v0.6

### DIFF
--- a/nvram_parser.py
+++ b/nvram_parser.py
@@ -510,11 +510,19 @@ class ParseNVRAM(object):
         """Process JSON file loaded into self.nv_json.  Sets self.big_endian and
         self.mapping, a normalized list of JSON entries as RamMapping objects.
         """
-        self.metadata['big_endian'] = self.nv_json.get('_endian') != 'little'
-        # save all metadata keys starting with "_"
-        for key in self.nv_json:
-            if key.startswith('_'):
-                self.metadata[key[1:]] = self.nv_json[key]
+        json_metadata = self.nv_json.get('_metadata')
+        if json_metadata:
+            # processing fileformat 0.6 or later
+            for key, value in json_metadata.items():
+                self.metadata[key] = value
+            self.metadata['big_endian'] = self.metadata['endian'] != 'little'
+        else:
+            # older file format with separate top-level properties with metadata
+            self.metadata['big_endian'] = self.nv_json.get('_endian') != 'little'
+            # save all metadata keys starting with "_"
+            for key in self.nv_json:
+                if key.startswith('_'):
+                    self.metadata[key[1:]] = self.nv_json[key]
         self.mapping = []
         for section in ['audits', 'adjustments']:
             for group in sorted(self.nv_json.get(section, {}).keys()):

--- a/test/expected/blakpyra.nv.txt
+++ b/test/expected/blakpyra.nv.txt
@@ -32,9 +32,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 2,186,150
 Player 2: 35,890
 Player 3: 33,160

--- a/test/expected/bmx.nv.txt
+++ b/test/expected/bmx.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for bmx.nv [BMX]...
 Game State
 ----------
 Credits: 7
-
-Player Scores
--------------
 Player 1: 115,620
 Player 2: 10,240
 Player 3: 0

--- a/test/expected/btmn_106.nv.txt
+++ b/test/expected/btmn_106.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/dataeast/version3/btmn_106.nv.json for btmn_106.nv
 Dumping known entries for btmn_106.nv [Batman (1.06)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 339,930
 Player 2: 1,868,230
 Player 3: 0

--- a/test/expected/centaur-2.nv.txt
+++ b/test/expected/centaur-2.nv.txt
@@ -34,9 +34,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 9,999,998
 Player 2: 9,999,980
 Player 3: 9

--- a/test/expected/centaur.nv.txt
+++ b/test/expected/centaur.nv.txt
@@ -34,9 +34,6 @@ High score functions
 Game State
 ----------
 Credits: 8
-
-Player Scores
--------------
 Player 1: 52,500
 Player 2: 0
 Player 3: 0

--- a/test/expected/dm_dt101.nv.txt
+++ b/test/expected/dm_dt101.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/williams/wpc/dm_dt101.nv.json for dm_dt101.nv
 Dumping known entries for dm_dt101.nv [Demolition Man (FreeWPC/Demolition Time 1.01)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/dollyptb.nv.txt
+++ b/test/expected/dollyptb.nv.txt
@@ -24,9 +24,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/dracula.nv.txt
+++ b/test/expected/dracula.nv.txt
@@ -23,13 +23,6 @@ Game State
 Match: 70
 Ball: n/a
 Credits: 0
-P1: 32,520
-P2: 22,510
-P3: 0
-P4: 0
-
-Player Scores
--------------
 Player 1: 32,520
 Player 2: 22,510
 Player 3: 0

--- a/test/expected/dvlrider.nv.txt
+++ b/test/expected/dvlrider.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for dvlrider.nv [Devil Riders]...
 Game State
 ----------
 Credits: 37
-
-Player Scores
--------------
 Player 1: 200,430
 Player 2: 129,760
 Player 3: 0

--- a/test/expected/eballdlx.nv.txt
+++ b/test/expected/eballdlx.nv.txt
@@ -36,9 +36,6 @@ Game State
 ----------
 Ball in play display: 0
 Credits display: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/elektra.nv.txt
+++ b/test/expected/elektra.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for elektra.nv [Elektra]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/embryon.nv.txt
+++ b/test/expected/embryon.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for embryon.nv [Embryon]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/embryond.nv.txt
+++ b/test/expected/embryond.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for embryond.nv [Embryon (7-digit conversion rev. 9)]...
 Game State
 ----------
 Credits: 10
-
-Player Scores
--------------
 Player 1: 43,380
 Player 2: 49,840
 Player 3: 0

--- a/test/expected/farfalla-hs-135.nv.txt
+++ b/test/expected/farfalla-hs-135.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for farfalla-hs-135.nv [Farfalla]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/farfalla.nv.txt
+++ b/test/expected/farfalla.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for farfalla.nv [Farfalla]...
 Game State
 ----------
 Credits: 48
-
-Player Scores
--------------
 Player 1: 94,220
 Player 2: 122,970
 Player 3: 166,030

--- a/test/expected/fathom.nv.txt
+++ b/test/expected/fathom.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for fathom.nv [Fathom]...
 Game State
 ----------
 Credits: 7
-
-Player Scores
--------------
 Player 1: 39,130
 Player 2: 25,110
 Player 3: 0

--- a/test/expected/fball_ii.nv.txt
+++ b/test/expected/fball_ii.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for fball_ii.nv [Fireball II]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/flashgdn.nv.txt
+++ b/test/expected/flashgdn.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for flashgdn.nv [Flash Gordon]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/freddy.nv.txt
+++ b/test/expected/freddy.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/gottlieb/system3/freddy.nv.json for freddy.nv
 Dumping known entries for freddy.nv [Freddy: A Nightmare on Elm Street (rev. 3)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/frontier.nv.txt
+++ b/test/expected/frontier.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for frontier.nv [Frontier]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/futurspa.nv.txt
+++ b/test/expected/futurspa.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for futurspa.nv [Future Spa]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/gransla4.nv.txt
+++ b/test/expected/gransla4.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for gransla4.nv [Grand Slam (4 Players)]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/hglbtrtb.nv.txt
+++ b/test/expected/hglbtrtb.nv.txt
@@ -24,9 +24,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 26,810
 Player 2: 23,710
 Player 3: 0

--- a/test/expected/hod.nv.txt
+++ b/test/expected/hod.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for hod.nv [House of Diamonds]...
 Game State
 ----------
 Credits: 8
-
-Player Scores
--------------
 Player 1: 57,290
 Player 2: 10,000
 Player 3: 0

--- a/test/expected/hotdoggb.nv.txt
+++ b/test/expected/hotdoggb.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for hotdoggb.nv [Hot Doggin (7-digit conversion)]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/hotdoggn.nv.txt
+++ b/test/expected/hotdoggn.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for hotdoggn.nv [Hot Doggin]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/jplstw22.nv.txt
+++ b/test/expected/jplstw22.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/sega/whitestar/jplstw22.nv.json for jplstw22.nv
 Dumping known entries for jplstw22.nv [Lost World: Jurassic Park, The (2.02)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 267,920
 Player 2: 0
 Player 3: 0

--- a/test/expected/kissc.nv.txt
+++ b/test/expected/kissc.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for kissc.nv [Kiss (Free Play rev. 3)]...
 Game State
 ----------
 Credits: 3
-
-Player Scores
--------------
 Player 1: 6,550
 Player 2: 10,520
 Player 3: 0

--- a/test/expected/kosteel.nv.txt
+++ b/test/expected/kosteel.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for kosteel.nv [Kings of Steel]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/lostwrld.nv.txt
+++ b/test/expected/lostwrld.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for lostwrld.nv [Lost World]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/m_mpac.nv.txt
+++ b/test/expected/m_mpac.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for m_mpac.nv [Mr. & Mrs. Pac-Man Pinball]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/mcastle.nv.txt
+++ b/test/expected/mcastle.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for mcastle.nv [Magic Castle]...
 Game State
 ----------
 Credits: 93
-
-Player Scores
--------------
 Player 1: 131,430
 Player 2: 113,210
 Player 3: 0

--- a/test/expected/medusa.nv.txt
+++ b/test/expected/medusa.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for medusa.nv [Medusa]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/mystic.nv.txt
+++ b/test/expected/mystic.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for mystic.nv [Mystic]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/mysticb.nv.txt
+++ b/test/expected/mysticb.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for mysticb.nv [Mystic (7-digit conversion)]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/newwave.nv.txt
+++ b/test/expected/newwave.nv.txt
@@ -25,9 +25,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/ngndshkb.nv.txt
+++ b/test/expected/ngndshkb.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for ngndshkb.nv [Nitro Groundshaker (7-digit conversion)].
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/ngndshkr.nv.txt
+++ b/test/expected/ngndshkr.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for ngndshkr.nv [Nitro Groundshaker]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/paragon.nv.txt
+++ b/test/expected/paragon.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for paragon.nv [Paragon]...
 Game State
 ----------
 Credits: 4
-
-Player Scores
--------------
 Player 1: 25,830
 Player 2: 14,330
 Player 3: 0

--- a/test/expected/pinchamp.nv.txt
+++ b/test/expected/pinchamp.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for pinchamp.nv [Pinball Champ]...
 Game State
 ----------
 Credits: 39
-
-Player Scores
--------------
 Player 1: 342,010
 Player 2: 1,521,110
 Player 3: 0

--- a/test/expected/playboy.nv.txt
+++ b/test/expected/playboy.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for playboy.nv [Playboy]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/playboyb.nv.txt
+++ b/test/expected/playboyb.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for playboyb.nv [Playboy (7-digit conversion rev. 20)]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/rapidfir.nv.txt
+++ b/test/expected/rapidfir.nv.txt
@@ -4,8 +4,5 @@ Dumping known entries for rapidfir.nv [Rapid Fire]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0

--- a/test/expected/ripleys.nv.txt
+++ b/test/expected/ripleys.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/whitestar/ripleys.nv.json for ripleys.nv
 Dumping known entries for ripleys.nv [Ripley's Believe It or Not! (3.20)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 30,030
 Player 2: 0
 Player 3: 0

--- a/test/expected/robo_a34.nv.txt
+++ b/test/expected/robo_a34.nv.txt
@@ -52,8 +52,8 @@ Feature Adjustments
 54 Scanning Extra Ball: 25
 55 Factory Restore: OFF
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 130,240
 Player 2: 0
 Player 3: 0

--- a/test/expected/robot.nv.txt
+++ b/test/expected/robot.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for robot.nv [Robot]...
 Game State
 ----------
 Credits: 22
-
-Player Scores
--------------
 Player 1: 166,350
 Player 2: 65,830
 Player 3: 105,190

--- a/test/expected/rollstob.nv.txt
+++ b/test/expected/rollstob.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for rollstob.nv [Rolling Stones (7-digit conversion)]...
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/skatebll.nv.txt
+++ b/test/expected/skatebll.nv.txt
@@ -9,9 +9,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/slbmanib.nv.txt
+++ b/test/expected/slbmanib.nv.txt
@@ -9,9 +9,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/smmanc.nv.txt
+++ b/test/expected/smmanc.nv.txt
@@ -14,9 +14,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 3
 Player 2: 0
 Player 3: 0

--- a/test/expected/socrking.nv.txt
+++ b/test/expected/socrking.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for socrking.nv [Soccer Kings]...
 Game State
 ----------
 Credits: 71
-
-Player Scores
--------------
 Player 1: 137,680
 Player 2: 414,950
 Player 3: 0

--- a/test/expected/spaceinb.nv.txt
+++ b/test/expected/spaceinb.nv.txt
@@ -9,9 +9,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 90
 Player 2: 0
 Player 3: 0

--- a/test/expected/speakes4.nv.txt
+++ b/test/expected/speakes4.nv.txt
@@ -18,9 +18,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/speakesy.nv.txt
+++ b/test/expected/speakesy.nv.txt
@@ -18,9 +18,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 

--- a/test/expected/spectru4.nv.txt
+++ b/test/expected/spectru4.nv.txt
@@ -18,9 +18,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/spyhuntr.nv.txt
+++ b/test/expected/spyhuntr.nv.txt
@@ -25,9 +25,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/sstb.nv.txt
+++ b/test/expected/sstb.nv.txt
@@ -14,9 +14,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 20
 Player 2: 0
 Player 3: 0

--- a/test/expected/st_161h-long-hs.nv.txt
+++ b/test/expected/st_161h-long-hs.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/sam/st_161h.nv.json for st_161h-long-hs.nv
 Dumping known entries for st_161h-long-hs.nv [Star Trek (Stern) Limited Edition (V1.61)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 3,617,980
 Player 2: 55,015,990
 Player 3: 0

--- a/test/expected/st_161h.nv.txt
+++ b/test/expected/st_161h.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/sam/st_161h.nv.json for st_161h.nv
 Dumping known entries for st_161h.nv [Star Trek (Stern) Limited Edition (V1.61)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 691,690
 Player 2: 0
 Player 3: 0

--- a/test/expected/st_162.nv.txt
+++ b/test/expected/st_162.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/sam/st_162.nv.json for st_162.nv
 Dumping known entries for st_162.nv [Star Trek (Stern) (V1.62)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/st_162h.nv.txt
+++ b/test/expected/st_162h.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/sam/st_162h.nv.json for st_162h.nv
 Dumping known entries for st_162h.nv [Star Trek (Stern) Limited Edition (V1.62)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/stargoda.nv.txt
+++ b/test/expected/stargoda.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for stargoda.nv [Star God (alternate sound)]...
 Game State
 ----------
 Credits: 17
-
-Player Scores
--------------
 Player 1: 61,610
 Player 2: 0
 Player 3: 0

--- a/test/expected/startreb.nv.txt
+++ b/test/expected/startreb.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for startreb.nv [Star Trek (7-digit conversion rev. 20)]..
 Game State
 ----------
 Credits: 5
-
-Player Scores
--------------
 Player 1: 1,184,620
 Player 2: 18,200
 Player 3: 0

--- a/test/expected/stingray.nv.txt
+++ b/test/expected/stingray.nv.txt
@@ -23,13 +23,6 @@ Game State
 Match: n/a
 Ball: 2
 Credits: 10
-P1: 41,440
-P2: 0
-P3: 0
-P4: 0
-
-Player Scores
--------------
 Player 1: 301,300
 Player 2: 0
 Player 3: 0

--- a/test/expected/strapids.nv.txt
+++ b/test/expected/strapids.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for strapids.nv [Shooting the Rapids]...
 Game State
 ----------
 Credits: 17
-
-Player Scores
--------------
 Player 1: 114,490
 Player 2: 65,920
 Player 3: 53,440

--- a/test/expected/suprbowl.nv.txt
+++ b/test/expected/suprbowl.nv.txt
@@ -25,9 +25,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/swtril43.nv.txt
+++ b/test/expected/swtril43.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/dataeast/version3/swtril43.nv.json for swtril43.nv
 Dumping known entries for swtril43.nv [Star Wars Trilogy Special Edition, The (4.03)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/tf_180.nv.txt
+++ b/test/expected/tf_180.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/stern/sam/tf_180.nv.json for tf_180.nv
 Dumping known entries for tf_180.nv [Transformers (V1.8)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 584,950
 Player 2: 0
 Player 3: 0

--- a/test/expected/tmachzac.nv.txt
+++ b/test/expected/tmachzac.nv.txt
@@ -4,9 +4,6 @@ Dumping known entries for tmachzac.nv [Time Machine (Zaccaria)]...
 Game State
 ----------
 Credits: 47
-
-Player Scores
--------------
 Player 1: 580,340
 Player 2: 43,100
 Player 3: 66,500

--- a/test/expected/tomy_500.nv.txt
+++ b/test/expected/tomy_500.nv.txt
@@ -1,8 +1,8 @@
 Using map ../maps/maps/dataeast/version3/tomy_400.nv.json for tomy_500.nv
 Dumping known entries for tomy_500.nv [Tommy Pinball Wizard, The Who's (5.00 unofficial MOD)]...
 
-Player Scores
--------------
+Game State
+----------
 Player 1: 4,702,109,630
 Player 2: 4,349,414,040
 Player 3: 4,152,202,031

--- a/test/expected/vector.nv.txt
+++ b/test/expected/vector.nv.txt
@@ -18,9 +18,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/vikingb.nv.txt
+++ b/test/expected/vikingb.nv.txt
@@ -17,9 +17,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/voltanb.nv.txt
+++ b/test/expected/voltanb.nv.txt
@@ -14,9 +14,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 20
 Player 2: 0
 Player 3: 0

--- a/test/expected/xenon.nv.txt
+++ b/test/expected/xenon.nv.txt
@@ -18,9 +18,6 @@ Bookkeeping functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0

--- a/test/expected/xsandosa.nv.txt
+++ b/test/expected/xsandosa.nv.txt
@@ -25,9 +25,6 @@ High score functions
 Game State
 ----------
 Credits: 0
-
-Player Scores
--------------
 Player 1: 0
 Player 2: 0
 Player 3: 0


### PR DESCRIPTION
- Moves metadata into new _metadata property.
- Replaces `last_game` with `game_state.scores`.

Moving toward maps having a defined "platform" with a memory layout containing addresses for RAM/NVRAM and per-device nibble properties (e.g., Gottlieb System 80 with 8-bit RAM and 4-bit NVRAM).